### PR TITLE
Downgrade MASS minor version in renv.lock to keep it installable

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -47,18 +47,8 @@
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-58.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "methods",
-        "stats",
-        "utils"
-      ],
-      "Hash": "a3142b2a022b8174ca675bc8b80cdc4e"
+      "Version": "7.3-58.3",
+      "Source": "Repository"
     },
     "Matrix": {
       "Package": "Matrix",


### PR DESCRIPTION
MASS version 7.3-58.4 seems to be unavailable for installation (neither in source or binary formats). However, MASS 7.3-58.3 seems to be available and installable with no issues. At least in my current (suboptimal) operating system at my work place, and R 4.2.2 64bit (even if that shouldn't matter much, thanks to renv). Therefore I suggest to change the version in renv.lock