### PR TITLE
Moving comments from tutorial 02a to 02b

### DIFF
--- a/inst/tutorials/02a-rstudio-and-code/tutorial.Rmd
+++ b/inst/tutorials/02a-rstudio-and-code/tutorial.Rmd
@@ -44,14 +44,6 @@ options(tutorial.exercise.timelimit = 60,
 
 <!-- We do not use the Terminal in this tutorial. Maybe mention it, though? -->
 
-<!-- Dealing with RPubs versus Quarto Pub versus Posit Cloud is annoying!  -->
-
-<!-- RPubs works well, just as it always has! It works from the publish button, which is nice for the initial learning. It produces a nice URL, which you can edit. The main page of your account is a nice portfolio of work. The only reason to move away is a fear that Rpubs will be going away. With luck, it isn't!-->
-
-<!-- Posit Cloud is available from the Publish button in RStudio. That is convenient! But sharing it more broadly is annoying. You have to click on the circle with three dots in the center, located in the upper right. Select the "Open Solo" option. This produces a super long and weird url, which does work for anyone. I can't find anyway to give someone a url for your main account, which they could then go to and see lots of your work. -->
-
-<!-- Quarto Pub is not available from the Publish button. Nor does the quarto package currently supporting publishing. -->
-
 <!-- Given the changes we have made to default settings, lots of these images should be redone. -->
 
 <!-- Do more to bring the new RStudio user docs into the discussion. -->

--- a/inst/tutorials/02b-rstudio-and-quarto/tutorial.Rmd
+++ b/inst/tutorials/02b-rstudio-and-quarto/tutorial.Rmd
@@ -28,6 +28,16 @@ options(tutorial.exercise.timelimit = 60,
 ```{r info-section, child = system.file("child_documents/info_section.Rmd", package = "tutorial.helpers")}
 ```
 
+<!-- Dealing with RPubs versus Quarto Pub versus Posit Cloud is annoying!  -->
+
+<!-- RPubs works well, just as it always has! It works from the publish button, which is nice for the initial learning. It produces a nice URL, which you can edit. The main page of your account is a nice portfolio of work. The only reason to move away is a fear that Rpubs will be going away. With luck, it isn't!-->
+
+<!-- Posit Cloud is available from the Publish button in RStudio. That is convenient! But sharing it more broadly is annoying. You have to click on the circle with three dots in the center, located in the upper right. Select the "Open Solo" option. This produces a super long and weird url, which does work for anyone. I can't find anyway to give someone a url for your main account, which they could then go to and see lots of your work. -->
+
+<!-- Quarto Pub is not available from the Publish button. Nor does the quarto package currently supporting publishing. -->
+
+<!-- MP: Comments moved from tutorial 02a are above this line.  -->
+
 ## Introduction
 ### 
 


### PR DESCRIPTION
When tutorial 2 was split into 02a and 02b, all the comments lumped in the beginning were put into tutorial 02a, even though some of them were for material covered by tutorial 02b. This is fixed here.